### PR TITLE
Fix going back after setting profile

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/main_screen/MainScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/main_screen/MainScreenTest.kt
@@ -1,3 +1,57 @@
 package ch.epfl.sdp.blindly.main_screen
 
-class MainScreenTest
+import androidx.lifecycle.Lifecycle
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoActivityResumedException
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.google.protobuf.NullValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.Matchers.`is`
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.isNull
+
+@HiltAndroidTest
+class MainScreenTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainScreen::class.java)
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        Intents.init()
+    }
+
+    @After
+    fun afterEach() {
+        Intents.release()
+    }
+
+    @Test
+    fun backButtonHandlesExit(){
+        Espresso.pressBack()
+        onView(withText("Yes")).perform(click())
+        Thread.sleep(500)
+        assertThat(activityRule.scenario.state, `is`(Lifecycle.State.DESTROYED))
+    }
+
+    @Test
+    fun backButtonHandlesStayInApp(){
+        Espresso.pressBack()
+        onView(withText("No")).perform(click())
+        Thread.sleep(500)
+        assertThat(activityRule.scenario.state, `is`(Lifecycle.State.RESUMED))
+    }
+
+
+}

--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/settings/SettingsTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/settings/SettingsTest.kt
@@ -176,7 +176,6 @@ class SettingsTest {
     @Test
     fun checkEmailOpens() {
         onView(withId(R.id.email_button)).perform(click())
-
         intended(
             Matchers.allOf(
                 hasComponent(SettingsUpdateEmail::class.java.name)
@@ -187,6 +186,7 @@ class SettingsTest {
     @Test
     fun clickingOnLogoutButtonFiresSplashScreen() {
         onView(withId(R.id.logout_button)).perform(click())
+        Thread.sleep(1000)
         intended(
             hasComponent(SplashScreen::class.java.name)
         )
@@ -195,6 +195,7 @@ class SettingsTest {
     @Test
     fun clickingOnDeleteAccountButtonFiresSplashScreen() {
         onView(withId(R.id.delete_account_button)).perform(click())
+        Thread.sleep(1000)
         intended(
             hasComponent(SplashScreen::class.java.name)
         )

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
@@ -1,5 +1,6 @@
 package ch.epfl.sdp.blindly.main_screen
 
+import android.app.AlertDialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
@@ -9,6 +10,7 @@ import ch.epfl.sdp.blindly.R
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
+
 
 /**
  * This activity holds the three fragments (Match, Message and Profile page)
@@ -45,4 +47,21 @@ class MainScreen : AppCompatActivity() {
             }
         })
     }
+
+    override fun onBackPressed() {
+        val builder: AlertDialog.Builder = AlertDialog.Builder(this)
+        builder.setTitle("Exit")
+        builder.setMessage("Are You Sure?")
+        builder.setPositiveButton("Yes") { dialog, _ ->
+            dialog.dismiss()
+            this.finishAffinity()
+        }
+        builder.setNegativeButton(
+            "No"
+        ) { dialog, _ -> dialog.dismiss() }
+        val alert: AlertDialog = builder.create()
+        alert.show()
+    }
+
+
 }

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
@@ -20,6 +20,10 @@ private const val MATCH = "Match"
 private const val MESSAGE = "Message"
 private const val PROFILE = "Profile"
 private const val MAP = "Map"
+private const val EXIT_DIALOG_TITLE = "Exit the app."
+private const val EXIT_DIALOG_MESSAGE = "Are You Sure?"
+private const val ANSWER_YES = "Yes"
+private const val ANSWER_NO = "No"
 
 
 @AndroidEntryPoint
@@ -50,14 +54,14 @@ class MainScreen : AppCompatActivity() {
 
     override fun onBackPressed() {
         val builder: AlertDialog.Builder = AlertDialog.Builder(this)
-        builder.setTitle("Exit the app.")
-        builder.setMessage("Are You Sure?")
-        builder.setPositiveButton("Yes") { dialog, _ ->
+        builder.setTitle(EXIT_DIALOG_TITLE)
+        builder.setMessage(EXIT_DIALOG_MESSAGE)
+        builder.setPositiveButton(ANSWER_YES) { dialog, _ ->
             dialog.dismiss()
             this.finishAffinity()
         }
         builder.setNegativeButton(
-            "No"
+            ANSWER_NO
         ) { dialog, _ -> dialog.dismiss() }
         val alert: AlertDialog = builder.create()
         alert.show()

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
@@ -50,7 +50,7 @@ class MainScreen : AppCompatActivity() {
 
     override fun onBackPressed() {
         val builder: AlertDialog.Builder = AlertDialog.Builder(this)
-        builder.setTitle("Exit")
+        builder.setTitle("Exit the app.")
         builder.setMessage("Are You Sure?")
         builder.setPositiveButton("Yes") { dialog, _ ->
             dialog.dismiss()


### PR DESCRIPTION
Having finished the profile setup (when in MainScreen) back button press prompts a message, asks the user to exit the app or not. This was needed not only after registering but also when a registered users signs into app. Because otherwise back button would send you back to splash screen and gets stuck there.

TODO : I realized that same problem is there if we press back button when signing up or signing in however there's not an activity that I can override ```backButtonPressed()``` because API handles the intent with ```getSignInIntent()```. Any idea is welcome on that front, otherwise this PR fixes the bug once profile setting is finished and once a user signs in.