### PR TITLE
fix jacoco exclude pattern

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,8 +158,8 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
             '**/*_Factory.class',
             '**/*_MembersInjector.class',
             '**/di/**',
-            '**/UserHelper.kt',
-            '**/UserRepository.kt'
+            '**/UserHelper.*',
+            '**/UserRepository.*'
     ]
     def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"


### PR DESCRIPTION
UserHelper and UserRepository weren't correctly excluded from code coverage reports, from what I understand jacoco operates on .class files, not kt files.
We need to exclude, .class files. As we were already excluding for all extensions I did the same, as it is probably the most reliable way to do so.