### PR TITLE
Remove a matched user

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapterTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapterTest.kt
@@ -3,16 +3,43 @@ package ch.epfl.sdp.blindly.main_screen.my_matches
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
-import ch.epfl.sdp.blindly.main_screen.my_matches.MyMatch
-import ch.epfl.sdp.blindly.main_screen.my_matches.MyMatchesAdapter
+import androidx.test.espresso.intent.Intents
+import ch.epfl.sdp.blindly.database.UserRepository
+import ch.epfl.sdp.blindly.user.UserHelper
+import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.MatcherAssert
 import org.hamcrest.core.IsEqual
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import javax.inject.Inject
 
 @HiltAndroidTest
 class MyMatchesAdapterTest {
+
+
+    @Inject
+    lateinit var userHelper: UserHelper
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        Intents.init()
+    }
+
+    @After
+    fun afterEach() {
+        Intents.release()
+    }
 
     companion object {
         private const val NAME_1 = "user1"
@@ -35,7 +62,9 @@ class MyMatchesAdapterTest {
                 list,
                 arrayListOf(),
                 ApplicationProvider.getApplicationContext(),
-                listener
+                listener,
+                userHelper,
+                userRepository
             )
 
         MatcherAssert.assertThat(viewHolder.itemCount, IsEqual.equalTo(2))
@@ -53,7 +82,9 @@ class MyMatchesAdapterTest {
                 list,
                 arrayListOf(),
                 ApplicationProvider.getApplicationContext(),
-                listener
+                listener,
+                userHelper,
+                userRepository
             )
         val defaultType = 0
         MatcherAssert.assertThat(viewHolder.getItemViewType(0), IsEqual.equalTo(defaultType))
@@ -72,7 +103,9 @@ class MyMatchesAdapterTest {
             list,
             arrayListOf(),
             ApplicationProvider.getApplicationContext(),
-            listener
+            listener,
+            userHelper,
+            userRepository
         )
         rv.adapter = adapter
         adapter.my_matches.add(MyMatch(NAME_1, UID_2, IS_EXPANDED))

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
@@ -54,12 +54,12 @@ class UserRepository @Inject constructor(
      * Removes another liked or matched user from current user.
      *
      * @param field field to remove a User (either from LIKES or MATCHES)
-     * @param userUid current user's UID
-     * @param matchUid matched user's UID
+     * @param userId current user's ID
+     * @param matchId matched user's ID
      */
-    suspend fun removeMatchFromAUser(field: String, userUid: String, matchUid:String) {
-        var updatedList: ArrayList<String>? = null
-        val user = getUser(userUid)
+    suspend fun removeMatchFromAUser(field: String, userId: String, matchId:String) {
+        var updatedList: ArrayList<String>? = arrayListOf()
+        val user = getUser(userId)
         if (user != null) {
             when (field) {
                 LIKES ->
@@ -67,7 +67,7 @@ class UserRepository @Inject constructor(
                 MATCHES ->
                     updatedList = user.matches as ArrayList<String>?
             }
-            updatedList?.remove(matchUid)
+            updatedList?.remove(matchId)
             if (user != null) {
                 user.uid?.let { updateProfile(it, field, updatedList) }
             }

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
@@ -1,13 +1,13 @@
 package ch.epfl.sdp.blindly.database
 
-import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import ch.epfl.sdp.blindly.main_screen.my_matches.MyMatch
 import ch.epfl.sdp.blindly.location.BlindlyLatLng
+import ch.epfl.sdp.blindly.main_screen.my_matches.MyMatch
 import ch.epfl.sdp.blindly.main_screen.profile.settings.LAUSANNE_LATLNG
+import ch.epfl.sdp.blindly.user.LIKES
+import ch.epfl.sdp.blindly.user.MATCHES
 import ch.epfl.sdp.blindly.user.User
 import ch.epfl.sdp.blindly.user.User.Companion.toUser
 import ch.epfl.sdp.blindly.user.storage.UserCache
@@ -48,6 +48,30 @@ class UserRepository @Inject constructor(
             return cached
         }
         return refreshUser(uid)
+    }
+
+    /**
+     * Removes another liked or matched user from current user.
+     *
+     * @param field field to remove a User (either from LIKES or MATCHES)
+     * @param userUid current user's UID
+     * @param matchUid matched user's UID
+     */
+    suspend fun removeMatchFromAUser(field: String, userUid: String, matchUid:String) {
+        var updatedList: ArrayList<String>? = null
+        val user = getUser(userUid)
+        if (user != null) {
+            when (field) {
+                LIKES ->
+                    updatedList = user.likes as ArrayList<String>?
+                MATCHES ->
+                    updatedList = user.matches as ArrayList<String>?
+            }
+            updatedList?.remove(matchUid)
+            if (user != null) {
+                user.uid?.let { updateProfile(it, field, updatedList) }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/MainScreen.kt
@@ -12,14 +12,11 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 
-private const val MATCH = "Match"
-private const val PROFILE = "Profile"
-private const val MY_MATCHES = "My Matches"
-private const val WEATHER = "Weather"
+
 private const val EXIT_DIALOG_TITLE = "Exit the app."
 private const val EXIT_DIALOG_MESSAGE = "Are You Sure?"
-private const val ANSWER_YES = "Yes"
-private const val ANSWER_NO = "No"
+const val ANSWER_YES = "Yes"
+const val ANSWER_NO = "No"
 
 /**
  * This activity holds the three fragments (Match, Message and Profile page)

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
@@ -171,7 +171,6 @@ class MyMatchesAdapter(
                                 my_matches[position].uid
                             )
                         }
-                    notifyDataSetChanged()
                 }
             }
             builder.setNegativeButton(

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
@@ -1,35 +1,47 @@
 package ch.epfl.sdp.blindly.main_screen.my_matches
 
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import android.widget.RelativeLayout
 import android.widget.TextView
-import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat.startActivity
 import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
 import ch.epfl.sdp.blindly.R
 import ch.epfl.sdp.blindly.animations.RecordAnimations
+import ch.epfl.sdp.blindly.database.UserRepository
+import ch.epfl.sdp.blindly.main_screen.ANSWER_NO
+import ch.epfl.sdp.blindly.main_screen.ANSWER_YES
+import ch.epfl.sdp.blindly.main_screen.map.UserMapActivity
 import ch.epfl.sdp.blindly.main_screen.my_matches.chat.ChatActivity
 import ch.epfl.sdp.blindly.main_screen.my_matches.match_profile.MatchProfileActivity
-import ch.epfl.sdp.blindly.main_screen.map.UserMapActivity
+import ch.epfl.sdp.blindly.user.LIKES
+import ch.epfl.sdp.blindly.user.MATCHES
+import ch.epfl.sdp.blindly.user.UserHelper
+import kotlinx.coroutines.runBlocking
+
 
 class MyMatchesAdapter(
     var my_matches: ArrayList<MyMatch>,
     private var viewHolderList: ArrayList<ViewHolder>,
     var context: Context,
-    private val listener: OnItemClickListener
+    private val listener: OnItemClickListener,
+    val userHelper: UserHelper,
+    val userRepository: UserRepository
 ) : RecyclerView.Adapter<MyMatchesAdapter.ViewHolder>() {
+
 
     companion object {
         const val BUNDLE_MATCHED_UID_LABEL = "matchedId"
         const val BUNDLE_MATCHED_USERNAME_LABEL = "username"
+        const val REMOVE_USER_WARNING_TITLE = "Remove User?"
+        const val REMOVE_USER_WARNING_MESSAGE =
+            "You'll no longer have this user as a match. Are you sure?"
     }
 
     /**
@@ -49,6 +61,7 @@ class MyMatchesAdapter(
         val chatButton: AppCompatImageButton = view.findViewById(R.id.chatButton)
         val profileButton: AppCompatImageButton = view.findViewById(R.id.profileButton)
         val mapButton: AppCompatImageButton = view.findViewById(R.id.mapButton)
+        val removeMatchButton: AppCompatImageButton = view.findViewById(R.id.removeMatchButton)
 
         init {
             userNameLayout.setOnClickListener(this)
@@ -114,7 +127,8 @@ class MyMatchesAdapter(
             val intent = Intent(context, ChatActivity::class.java)
             val bundle = bundleOf(
                 BUNDLE_MATCHED_UID_LABEL to my_matches[position].uid,
-                BUNDLE_MATCHED_USERNAME_LABEL to my_matches[position].name)
+                BUNDLE_MATCHED_USERNAME_LABEL to my_matches[position].name
+            )
             intent.putExtras(bundle)
             startActivity(context, intent, null)
         }
@@ -132,6 +146,41 @@ class MyMatchesAdapter(
             intent.putExtras(bundle)
             startActivity(context, intent, null)
         }
+        // On click, prompt user a message whether they are sure to remove a match
+        // If so remove the user
+        viewHolder.removeMatchButton.setOnClickListener {
+            val builder: AlertDialog.Builder = AlertDialog.Builder(context)
+            builder.setTitle(REMOVE_USER_WARNING_TITLE)
+            builder.setMessage(REMOVE_USER_WARNING_MESSAGE)
+            builder.setPositiveButton(ANSWER_YES) { dialog, _ ->
+                dialog.dismiss()
+                runBlocking {
+                    userHelper.getUserId()
+                        ?.let { it1 ->
+                            userRepository.removeMatchFromAUser(
+                                LIKES,
+                                it1,
+                                my_matches[position].uid
+                            )
+                        }
+                    userHelper.getUserId()
+                        ?.let { it1 ->
+                            userRepository.removeMatchFromAUser(
+                                MATCHES,
+                                it1,
+                                my_matches[position].uid
+                            )
+                        }
+                    notifyDataSetChanged()
+                }
+            }
+            builder.setNegativeButton(
+                ANSWER_NO
+            ) { dialog, _ -> dialog.dismiss() }
+            val alert: AlertDialog = builder.create()
+            alert.show()
+        }
+
     }
 
     override fun getItemCount() = my_matches.size

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesFragment.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesFragment.kt
@@ -115,7 +115,7 @@ class MyMatchesFragment : Fragment(), MyMatchesAdapter.OnItemClickListener {
     private fun setupRecylerView(myMatches: ArrayList<MyMatch>) {
         myMatchesRecyclerView = fragView.findViewById(R.id.my_matches_recyler_view)
         myMatchesRecyclerView.layoutManager = LinearLayoutManager(context)
-        adapter = MyMatchesAdapter(myMatches, arrayListOf(), requireContext(), this)
+        adapter = MyMatchesAdapter(myMatches, arrayListOf(), requireContext(), this, userHelper, userRepository)
         myMatchesRecyclerView.adapter = adapter
     }
 

--- a/app/src/main/java/ch/epfl/sdp/blindly/user/User.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/user/User.kt
@@ -338,12 +338,18 @@ class User private constructor(
                     user.radius = newValue as Int
                 }
                 MATCHES -> {
-                    assertIsListOfString(newValue)
-                    user.matches = newValue as List<String>
+                    val newMatches = newValue as List<String>
+                    if(newMatches.isNotEmpty()){
+                        assertIsListOfString(newValue)
+                        user.matches = newMatches
+                    }
                 }
                 LIKES -> {
-                    assertIsListOfString(newValue)
-                    user.likes = newValue as List<String>
+                    val newLikes = newValue as List<String>
+                    if(newLikes.isNotEmpty()){
+                        assertIsListOfString(newValue)
+                        user.likes = newLikes
+                    }
                 }
                 RECORDING_PATH -> {
                     assertIsString(newValue)

--- a/app/src/main/res/drawable/remove_my_match_icon.xml
+++ b/app/src/main/res/drawable/remove_my_match_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/holo_red_light" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/app/src/main/res/layout/my_matched_user_item.xml
+++ b/app/src/main/res/layout/my_matched_user_item.xml
@@ -17,7 +17,7 @@
 
         <TextView
             android:id="@+id/matchedUserName"
-            android:layout_width="0dp"
+            android:layout_width="257dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_weight="50"
@@ -25,6 +25,13 @@
             android:textColor="#000000"
             android:textSize="24sp"
             tools:layout_marginLeft="20dp" />
+
+        <ImageButton
+            android:id="@+id/removeMatchButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/remove_my_match_icon"
+            android:contentDescription="@string/button_to_remove_a_match" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/my_matched_user_item.xml
+++ b/app/src/main/res/layout/my_matched_user_item.xml
@@ -17,7 +17,7 @@
 
         <TextView
             android:id="@+id/matchedUserName"
-            android:layout_width="257dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_weight="50"

--- a/app/src/main/res/layout/my_matched_user_item.xml
+++ b/app/src/main/res/layout/my_matched_user_item.xml
@@ -30,6 +30,7 @@
             android:id="@+id/removeMatchButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
             android:background="@drawable/remove_my_match_icon"
             android:contentDescription="@string/button_to_remove_a_match" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,4 +176,5 @@
     <string name="loading_profiles">Profiles are loading, please wait…</string>
     <string name="match_profile_background_description">Gradient background with sound waves</string>
     <string name="my_profile_button_description">Profile button</string>
+    <string name="button_to_remove_a_match">Button to remove a match.</string>
 </resources>

--- a/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
+++ b/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
@@ -29,8 +29,8 @@ class UserTest {
         private val matches: List<String> = listOf("a1", "b2")
         private val matches2: List<String> = listOf("A3Verg34vrE3")
         private val likes: List<String> = listOf("c3", "d4")
-        private val emptyLikes : List<String> = listOf()
-        private val emptyMatches : List<String> = listOf()
+        private val emptyLikes: List<String> = listOf()
+        private val emptyMatches: List<String> = listOf()
         private val likes2: List<String> = listOf("efh14fjnaA")
         private val ageRange = listOf(30, 40)
         private val ageRange2 = listOf(20, 60)
@@ -320,12 +320,6 @@ class UserTest {
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun updateMatchesWithOtherThanListThrowsException() {
-        val user = buildUser()
-        User.updateUser(user, MATCHES, WRONG_INPUT_FOR_LIST)
-    }
-
-    @Test(expected = IllegalArgumentException::class)
     fun updateMatchesWithOtherThanListOfStringThrowsException() {
         val user = buildUser()
         User.updateUser(user, MATCHES, WRONG_INPUT_FOR_LIST_STRING)
@@ -336,12 +330,6 @@ class UserTest {
         val user = buildUser()
         User.updateUser(user, LIKES, likes2)
         assertThat(user.likes, equalTo(likes2))
-    }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun updateLikesWithOtherThanListThrowsException() {
-        val user = buildUser()
-        User.updateUser(user, LIKES, WRONG_INPUT_FOR_LIST)
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
+++ b/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
@@ -29,6 +29,8 @@ class UserTest {
         private val matches: List<String> = listOf("a1", "b2")
         private val matches2: List<String> = listOf("A3Verg34vrE3")
         private val likes: List<String> = listOf("c3", "d4")
+        private val emptyLikes : List<String> = listOf()
+        private val emptyMatches : List<String> = listOf()
         private val likes2: List<String> = listOf("efh14fjnaA")
         private val ageRange = listOf(30, 40)
         private val ageRange2 = listOf(20, 60)
@@ -108,6 +110,18 @@ class UserTest {
     fun setLikesIsCorrect() {
         val userBuilder = User.Builder().setLikes(likes)
         assertThat(userBuilder.likes, equalTo(likes))
+    }
+
+    @Test
+    fun setEmptyLikesListIsCorrect() {
+        val userBuilder = User.Builder().setLikes(emptyLikes)
+        assertThat(userBuilder.likes, equalTo(emptyLikes))
+    }
+
+    @Test
+    fun setEmptyMatchesListIsCorrect() {
+        val userBuilder = User.Builder().setLikes(emptyMatches)
+        assertThat(userBuilder.matches, equalTo(emptyMatches))
     }
 
     @Test


### PR DESCRIPTION
Added ability to remove a user from My Matches. The manipulation in UserRepository is pretty similar to @cmsigrist 's code to Delete an Account, we can reuse it there. The user has a remove button besides the match's name. When clicked, a warning message is prompted and if user proceeds, that match is removed from My Matches.

Most of the manipulation is already in UserRepository however for testing the warning message, @Xelowak can address this in his testing task #241 .