### PR TITLE
Fix remove match

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
@@ -12,10 +12,7 @@ import ch.epfl.sdp.blindly.fake_module.FakeUserHelperModule.Companion.TEST_UID3
 import ch.epfl.sdp.blindly.location.AndroidLocationService
 import ch.epfl.sdp.blindly.location.BlindlyLatLng
 import ch.epfl.sdp.blindly.main_screen.my_matches.MyMatch
-import ch.epfl.sdp.blindly.user.DELETED
-import ch.epfl.sdp.blindly.user.LIKES
-import ch.epfl.sdp.blindly.user.MATCHES
-import ch.epfl.sdp.blindly.user.User
+import ch.epfl.sdp.blindly.user.*
 import ch.epfl.sdp.blindly.user.User.Companion.updateUser
 import ch.epfl.sdp.blindly.user.storage.UserCache
 import com.google.android.gms.tasks.TaskCompletionSource
@@ -168,23 +165,35 @@ open class FakeUserRepositoryModule {
                 return db.getOrDefault(uid, fakeUser)
             }
 
+            override suspend fun removeCurrentUserFromRemovedMatch(
+                removingUserId: String,
+                removedUserId: String
+            ) {
+                val user = getUser(removedUserId)
+                if (user != null) {
+                    var updatedMatchesList = user.matches as ArrayList<String>?
+                    updatedMatchesList?.remove(removingUserId)
+                    user.uid?.let { updateProfile(it, MATCHES, updatedMatchesList) }
+                }
+            }
+
             override suspend fun removeMatchFromRemovingUser(
                 userId: String,
                 matchId: String
             ) {
-                var updatedList: List<String>? = listOf()
                 val user = getUser(userId)
                 if (user != null) {
-                    when (field) {
-                        LIKES ->
-                            updatedList = user.likes
-                        MATCHES ->
-                            updatedList = user.matches
-                    }
-                    if (updatedList != null) {
-                        updatedList = updatedList - listOf(matchId)
-                    }
-                    user.uid?.let { updateProfile(it, field, updatedList) }
+                    var updatedLikesList = user.likes as ArrayList<String>?
+                    var updatedDislikesList = user.dislikes as ArrayList<String>?
+                    var updatedMatchesList = user.matches as ArrayList<String>?
+
+                    updatedLikesList?.remove(matchId)
+                    updatedDislikesList?.add(matchId)
+                    updatedMatchesList?.remove(matchId)
+
+                    user.uid?.let { updateProfile(it, LIKES, updatedLikesList) }
+                    user.uid?.let { updateProfile(it, DISLIKES, updatedDislikesList) }
+                    user.uid?.let { updateProfile(it, MATCHES, updatedMatchesList) }
                 }
             }
 

--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
@@ -177,7 +177,7 @@ open class FakeUserRepositoryModule {
                 }
             }
 
-            override suspend fun removeMatchFromRemovingUser(
+            override suspend fun removeMatchFromCurrentUser(
                 userId: String,
                 matchId: String
             ) {

--- a/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindly/fake_module/FakeUserRepositoryModule.kt
@@ -168,8 +168,7 @@ open class FakeUserRepositoryModule {
                 return db.getOrDefault(uid, fakeUser)
             }
 
-            override suspend fun removeMatchFromAUser(
-                field: String,
+            override suspend fun removeMatchFromRemovingUser(
                 userId: String,
                 matchId: String
             ) {

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
@@ -52,7 +52,7 @@ interface UserRepository {
      * @param userId current user's ID
      * @param matchId matched user's ID
      */
-    suspend fun removeMatchFromRemovingUser(userId: String, matchId: String)
+    suspend fun removeMatchFromCurrentUser(userId: String, matchId: String)
 
     /**
      * Removes the current user from removed user's matches

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepository.kt
@@ -46,13 +46,23 @@ interface UserRepository {
 
 
     /**
-     * Removes another liked or matched user from current user.
+     * Removes a match from cuurent user, by deleting it from likes and matches
+     * and then adding to dislikes (to prevent reappear)
      *
-     * @param field field to remove a User (either from LIKES or MATCHES)
      * @param userId current user's ID
      * @param matchId matched user's ID
      */
-    suspend fun removeMatchFromAUser(field: String, userId: String, matchId: String)
+    suspend fun removeMatchFromRemovingUser(userId: String, matchId: String)
+
+    /**
+     * Removes the current user from removed user's matches
+     * It's kept in likes of remote user so that they wouldn't reappear
+     * in their cards
+     *
+     * @param removingUserId
+     * @param removedUserId
+     */
+    suspend fun removeCurrentUserFromRemovedMatch(removingUserId : String, removedUserId : String)
 
     /**
      * Remove a user from either the Matches or Liked list from all user that contains them

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepositoryImpl.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepositoryImpl.kt
@@ -186,7 +186,7 @@ class UserRepositoryImpl constructor(
      * @param userId current user's ID
      * @param matchId matched user's ID
      */
-    override suspend fun removeMatchFromRemovingUser(
+    override suspend fun removeMatchFromCurrentUser(
         userId: String,
         matchId: String
     ) {
@@ -209,20 +209,20 @@ class UserRepositoryImpl constructor(
 
     /**
      * Removes the current user from removed user's matches
-     * It's kept in likes of remote user so that they wouldn't reappear
+     * It's kept in likes of remote user so that they don't reappear
      * in their cards
      *
-     * @param removingUserId
+     * @param currentUserId
      * @param removedUserId
      */
     override suspend fun removeCurrentUserFromRemovedMatch(
-        removingUserId: String,
+        currentUserId: String,
         removedUserId: String
     ) {
         val user = getUser(removedUserId)
         if (user != null) {
             var updatedMatchesList = user.matches as ArrayList<String>?
-            updatedMatchesList?.remove(removingUserId)
+            updatedMatchesList?.remove(currentUserId)
             user.uid?.let { updateProfile(it, MATCHES, updatedMatchesList) }
         }
     }

--- a/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepositoryImpl.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/database/UserRepositoryImpl.kt
@@ -181,24 +181,49 @@ class UserRepositoryImpl constructor(
 
 
     /**
-     * Removes another liked or matched user from current user.
+     * Removes a matched user from likes and matches and adds it to dislikes.
      *
-     * @param field field to remove a User (either from LIKES or MATCHES)
      * @param userId current user's ID
      * @param matchId matched user's ID
      */
-    override suspend fun removeMatchFromAUser(field: String, userId: String, matchId: String) {
-        var updatedList: ArrayList<String>? = arrayListOf()
+    override suspend fun removeMatchFromRemovingUser(
+        userId: String,
+        matchId: String
+    ) {
         val user = getUser(userId)
         if (user != null) {
-            when (field) {
-                LIKES ->
-                    updatedList = user.likes as ArrayList<String>?
-                MATCHES ->
-                    updatedList = user.matches as ArrayList<String>?
-            }
-            updatedList?.remove(matchId)
-            user.uid?.let { updateProfile(it, field, updatedList) }
+            var updatedLikesList = user.likes as ArrayList<String>?
+            var updatedDislikesList = user.dislikes as ArrayList<String>?
+            var updatedMatchesList = user.matches as ArrayList<String>?
+
+            updatedLikesList?.remove(matchId)
+            updatedDislikesList?.add(matchId)
+            updatedMatchesList?.remove(matchId)
+
+            user.uid?.let { updateProfile(it, LIKES, updatedLikesList) }
+            user.uid?.let { updateProfile(it, DISLIKES, updatedDislikesList) }
+            user.uid?.let { updateProfile(it, MATCHES, updatedMatchesList) }
+        }
+    }
+
+
+    /**
+     * Removes the current user from removed user's matches
+     * It's kept in likes of remote user so that they wouldn't reappear
+     * in their cards
+     *
+     * @param removingUserId
+     * @param removedUserId
+     */
+    override suspend fun removeCurrentUserFromRemovedMatch(
+        removingUserId: String,
+        removedUserId: String
+    ) {
+        val user = getUser(removedUserId)
+        if (user != null) {
+            var updatedMatchesList = user.matches as ArrayList<String>?
+            updatedMatchesList?.remove(removingUserId)
+            user.uid?.let { updateProfile(it, MATCHES, updatedMatchesList) }
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
@@ -175,7 +175,7 @@ class MyMatchesAdapter(
                 runBlocking {
                     userHelper.getUserId()
                         ?.let { it1 ->
-                            userRepository.removeMatchFromRemovingUser(
+                            userRepository.removeMatchFromCurrentUser(
                                 it1,
                                 my_matches[position].uid
                             )

--- a/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/main_screen/my_matches/MyMatchesAdapter.kt
@@ -22,8 +22,6 @@ import ch.epfl.sdp.blindly.main_screen.ANSWER_YES
 import ch.epfl.sdp.blindly.main_screen.map.UserMapActivity
 import ch.epfl.sdp.blindly.main_screen.my_matches.chat.ChatActivity
 import ch.epfl.sdp.blindly.main_screen.my_matches.match_profile.MatchProfileActivity
-import ch.epfl.sdp.blindly.user.LIKES
-import ch.epfl.sdp.blindly.user.MATCHES
 import ch.epfl.sdp.blindly.user.UserHelper
 import kotlinx.coroutines.runBlocking
 
@@ -177,20 +175,16 @@ class MyMatchesAdapter(
                 runBlocking {
                     userHelper.getUserId()
                         ?.let { it1 ->
-                            userRepository.removeMatchFromAUser(
-                                LIKES,
+                            userRepository.removeMatchFromRemovingUser(
                                 it1,
                                 my_matches[position].uid
                             )
                         }
-                    userHelper.getUserId()
-                        ?.let { it1 ->
-                            userRepository.removeMatchFromAUser(
-                                MATCHES,
-                                it1,
-                                my_matches[position].uid
-                            )
-                        }
+                    userHelper.getUserId()?.let { it1 ->
+                        userRepository.removeCurrentUserFromRemovedMatch(
+                            it1, my_matches[position].uid
+                        )
+                    }
                 }
             }
             builder.setNegativeButton(ANSWER_NO) { dialog, _ -> dialog.dismiss() }

--- a/app/src/main/java/ch/epfl/sdp/blindly/user/User.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindly/user/User.kt
@@ -20,6 +20,7 @@ const val PASSIONS = "passions"
 const val RADIUS = "radius"
 const val MATCHES = "matches"
 const val LIKES = "likes"
+const val DISLIKES = "dislikes"
 const val RECORDING_PATH = "recordingPath"
 const val AGE_RANGE = "ageRange"
 const val REPORTING_USERS = "reportingUsers"
@@ -41,6 +42,7 @@ data class User private constructor(
     var radius: Int?,
     var matches: List<String>?,
     var likes: List<String>?,
+    var dislikes: List<String>?,
     var recordingPath: String?,
     var ageRange: List<Int>?,
     var deleted: Boolean,
@@ -79,6 +81,7 @@ data class User private constructor(
         var radius: Int? = null,
         var matches: List<String> = listOf(),
         var likes: List<String> = listOf(),
+        var dislikes: List<String>? = listOf(),
         var recordingPath: String? = null,
         var ageRange: List<Int> = listOf()
     ) {
@@ -188,6 +191,15 @@ data class User private constructor(
         }
 
         /**
+         * Set the dislikes in the UserBuilder
+         *
+         * @param dislikes the dislikes of the User. Other users are represented by their UID.
+         */
+        fun setDislikes(dislikes: List<String>) = apply {
+            this.dislikes = dislikes
+        }
+
+        /**
          * Set the recording path in the UserBuilder
          *
          * @param recordingPath the path to the recording
@@ -232,6 +244,7 @@ data class User private constructor(
                 radius,
                 matches,
                 likes,
+                dislikes,
                 recordingPath,
                 ageRange,
                 false,
@@ -261,6 +274,7 @@ data class User private constructor(
                 val radius = getField<Int>(RADIUS)!!
                 val matches = get(MATCHES) as? List<String>
                 val likes = get(LIKES) as? List<String>
+                val dislikes = get(DISLIKES) as? List<String>
                 val ageRange = get(AGE_RANGE) as? List<Long>
                 val recordingPath = getString(RECORDING_PATH)!!
                 val deleted = getField<Boolean>(DELETED)!!
@@ -278,6 +292,7 @@ data class User private constructor(
                     radius,
                     matches,
                     likes,
+                    dislikes,
                     recordingPath,
                     listOf(
                         ageRange!![0].toInt(),
@@ -362,6 +377,13 @@ data class User private constructor(
                         assertIsListOfString(newValue)
                     }
                     user.likes = newLikes
+                }
+                DISLIKES -> {
+                    val newDislikes = newValue as List<String>
+                    if (newDislikes.isNotEmpty()) { // newLikes is a non empty list, the type must be a string
+                        assertIsListOfString(newValue)
+                    }
+                    user.dislikes = newDislikes
                 }
                 RECORDING_PATH -> {
                     assertIsString(newValue)

--- a/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
+++ b/app/src/test/java/ch/epfl/sdp/blindly/UserTest.kt
@@ -30,7 +30,9 @@ class UserTest {
         private val matches: List<String> = listOf("a1", "b2")
         private val matches2: List<String> = listOf("A3Verg34vrE3")
         private val likes: List<String> = listOf("c3", "d4")
+        private val dislikes : List<String> = listOf("c1", "c2")
         private val emptyLikes: List<String> = listOf()
+        private val emptyDislikes: List<String> = listOf()
         private val emptyMatches: List<String> = listOf()
         private val likes2: List<String> = listOf("efh14fjnaA")
         private val ageRange = listOf(30, 40)
@@ -127,6 +129,12 @@ class UserTest {
     fun setEmptyMatchesListIsCorrect() {
         val userBuilder = User.Builder().setLikes(emptyMatches)
         assertThat(userBuilder.matches, equalTo(emptyMatches))
+    }
+
+    @Test
+    fun setEmptyDislikesListIsCorrect() {
+        val userBuilder = User.Builder().setLikes(emptyDislikes)
+        assertThat(userBuilder.dislikes, equalTo(emptyDislikes))
     }
 
     @Test
@@ -337,6 +345,19 @@ class UserTest {
     fun updateMatchesWithOtherThanListOfStringThrowsException() {
         val user = buildUser()
         User.updateUser(user, MATCHES, WRONG_INPUT_FOR_LIST_STRING)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun updateDislikesWithOtherThanListOfStringThrowsException() {
+        val user = buildUser()
+        User.updateUser(user, DISLIKES, WRONG_INPUT_FOR_LIST_STRING)
+    }
+
+    @Test
+    fun updateDislikesWithNonEmptyListIsCorrect() {
+        val user = buildUser()
+        User.updateUser(user, DISLIKES, dislikes)
+        assertThat(user.dislikes, equalTo(dislikes))
     }
 
     @Test


### PR DESCRIPTION
Now removing a match works correctly. When the current user (removing user), removes a match from its matches, that user is removed from likes and matches and put to dislikes so that match won't appear again cards. We also remove the remote user's match (current user) but keep the current user's id in remote's likes so that it won't reappear in its cards.